### PR TITLE
make laser scan task public to access for configure in Startup.cpp.

### DIFF
--- a/src/optional/HokuyoLaserDriver.hpp
+++ b/src/optional/HokuyoLaserDriver.hpp
@@ -9,14 +9,14 @@ namespace init
 
 class HokuyoLaserDriver : public LaserDriver
 {
-public:
+public: 
+    DependentTask<hokuyo::proxies::Task> laserTask;
     HokuyoLaserDriver(const std::string &hokuyoTaskName, const std::string &filterTaskName);
 
     virtual bool connect();
 
     virtual OutputProxyPort< base::samples::LaserScan >& getLaserReadingsPort();
 protected:
-    DependentTask<hokuyo::proxies::Task> laserTask;
     DependentTask<laser_filter::proxies::Task> filterTask;
 };
 }


### PR DESCRIPTION
neccessary to configure hokuyo task in Startup.cpp
